### PR TITLE
always output LF line endings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "build-w": "tsc -w"
+    "build-w": "tsc -w",
+    "prepack": "yarn build"
   },
   "dependencies": {
     "@prisma/client": "^3.4.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "baseUrl": ".",
     "moduleResolution": "Node",
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "newLine": "lf"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
this should prevent issues like #2. I haven't tested this on windows yet, but I think it should work fine there. I think the shebang is only a problem in unix based OSes